### PR TITLE
Create sapi-1.0.0 release branch

### DIFF
--- a/cirrus.conf
+++ b/cirrus.conf
@@ -1,6 +1,6 @@
 [package]
 name = cirrus-cli
-version = 0.1.7
+version = sapi-1.0.0
 description = cirrus development and build git extensions
 organization = evansde77
 version_file = src/cirrus/__init__.py

--- a/src/cirrus/__init__.py
+++ b/src/cirrus/__init__.py
@@ -18,5 +18,4 @@ Copyright 2013 Dave Evans
    See the License for the specific language governing permissions and
    limitations under the License.
 """
-__version__="0.1.7"
-
+__version__="sapi-1.0.0"


### PR DESCRIPTION
Because we work from an old release, `0.1.7` I have created a new branch called `new-development` as a replacement for our `development` branch.

We do not want to bring in changes from the original repo we forked this from.

This updates `new-development` release to sapi-1.0.0.

