### PR TITLE
Create release 1.0.0

### DIFF
--- a/cirrus.conf
+++ b/cirrus.conf
@@ -1,8 +1,8 @@
 [package]
 name = cirrus-cli
-version = sapi-1.0.0
+version = 1.0.0
 description = cirrus development and build git extensions
-organization = evansde77
+organization = cloudant
 version_file = src/cirrus/__init__.py
 
 [gitflow]

--- a/src/cirrus/__init__.py
+++ b/src/cirrus/__init__.py
@@ -18,4 +18,4 @@ Copyright 2013 Dave Evans
    See the License for the specific language governing permissions and
    limitations under the License.
 """
-__version__="sapi-1.0.0"
+__version__="1.0.0"


### PR DESCRIPTION
pip does not like the version name sapi-1.0.0, so I'm calling it plain 1.0.0.