### PR TITLE
Update cirrus for artifactory

### DIFF
--- a/cirrus.conf
+++ b/cirrus.conf
@@ -35,6 +35,5 @@ threshold = 10
 where = tests/
 
 [pypi]
-pypi_url = pypi.cloudant.com
-pypi_upload_path = /opt/pypi-server/packages/
+pypi_url = na.artifactory.swg-devops.com/artifactory/api/pypi/wcp-sapi-pypi-virtual
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 argparse==1.2.1
 arrow==0.4.2
 Fabric==1.11.1
-GitPython==0.3.5
+GitPython==2.1.9
 mock==1.0.1
 nose==1.3.0
 pep8==1.5.7


### PR DESCRIPTION
Update to latest GitPython. This fixes errors like the one seen below.

```
$ git cirrus release new --micro
2018-04-06;INFO;Creating new release...
2018-04-06;INFO;release branch is release/3.0.2
Traceback (most recent call last):
  File "/Users/shudgston/.cirrus/venv/bin/release", line 11, in <module>
    sys.exit(main())
  File "/Users/shudgston/.cirrus/venv/lib/python2.7/site-packages/cirrus/release.py", line 920, in main
    new_release(opts)
  File "/Users/shudgston/.cirrus/venv/lib/python2.7/site-packages/cirrus/release.py", line 538, in new_release
    branch(repo_dir, branch_name, main_branch)
  File "/Users/shudgston/.cirrus/venv/lib/python2.7/site-packages/cirrus/git_tools.py", line 49, in branch
    if branchname in repo.heads:
  File "/Users/shudgston/.cirrus/venv/lib/python2.7/site-packages/git/repo/base.py", line 221, in heads
    return Head.list_items(self)
  File "/Users/shudgston/.cirrus/venv/lib/python2.7/site-packages/git/util.py", line 693, in list_items
    out_list.extend(cls.iter_items(repo, *args, **kwargs))
  File "/Users/shudgston/.cirrus/venv/lib/python2.7/site-packages/git/refs/symbolic.py", line 591, in _iter_items
    for sha, rela_path in cls._iter_packed_refs(repo):
  File "/Users/shudgston/.cirrus/venv/lib/python2.7/site-packages/git/refs/symbolic.py", line 98, in _iter_packed_refs
    raise TypeError("PackingType of packed-Refs not understood: %r" % line)
TypeError: PackingType of packed-Refs not understood: '# pack-refs with: peeled fully-peeled sorted'
```