### PR TITLE
pypi url escape

### DIFF
--- a/src/cirrus/build.py
+++ b/src/cirrus/build.py
@@ -11,6 +11,7 @@ This command:
 """
 import os
 import sys
+from urllib.parse import quote_plus
 from argparse import ArgumentParser
 
 from cirrus.documentation_utils import build_docs
@@ -80,8 +81,6 @@ def build_parser(argslist):
 
 def execute_build(opts):
     """
-    _execute_build_
-
     Execute the build in the current package context.
 
     - reads the config to check for custom build parameters
@@ -129,19 +128,7 @@ def execute_build(opts):
     pip_options = config.pip_options()
     pip_command_base = None
     if pypi_server is not None:
-
-        pypirc = PypircFile()
-        if pypi_server in pypirc.index_servers:
-            pypi_url = pypirc.get_pypi_url(pypi_server)
-        else:
-            pypi_conf = get_pypi_auth()
-            pypi_url = (
-                "https://{pypi_username}:{pypi_token}@{pypi_server}/simple"
-            ).format(
-                pypi_token=pypi_conf['token'],
-                pypi_username=pypi_conf['username'],
-                pypi_server=pypi_server
-            )
+        pypi_url = config.pypi_url()
 
         pip_command_base = (
             '{0}/bin/pip install -i {1}'

--- a/src/cirrus/configuration.py
+++ b/src/cirrus/configuration.py
@@ -12,8 +12,6 @@ conf = load_configuration()
 import configparser
 import os
 import pluggage.registry
-import subprocess
-from urllib.parse import quote_plus
 
 from cirrus.gitconfig import load_gitconfig
 from cirrus.environment import repo_directory
@@ -161,11 +159,9 @@ class Configuration(dict):
         Returns the full pypi url (simple) with credentials
         """
         pypi_creds = self.credentials.pypi_credentials()
-        encoded_username = quote_plus(pypi_creds['username'])
-        encoded_token = quote_plus(pypi_creds['token'])
         return 'https://{username}:{token}@{server}/simple'.format(
-            username=encoded_username,
-            token=encoded_token,
+            username=pypi_creds['username'],
+            token=pypi_creds['token'],
             server=self.pypi_server()
         )
 

--- a/tests/unit/cirrus/build_tests.py
+++ b/tests/unit/cirrus/build_tests.py
@@ -109,25 +109,6 @@ class BuildCommandTests(TestCase):
             mock.call('. ./venv/bin/activate && python setup.py develop')
         ])
 
-    def test_execute_build_pypirc(self):
-        """test execute_build with pypirc provided settings"""
-        opts = mock.Mock()
-        opts.clean = False
-        opts.upgrade = False
-        opts.extras = []
-        opts.nosetupdevelop = False
-
-        self.mock_conf.pypi_url.return_value = "dev"
-        self.mock_pypirc_inst.index_servers = ['dev']
-        self.mock_pypirc_inst.get_pypi_url = mock.Mock(return_value="DEVPYPIURL")
-        execute_build(opts)
-
-        self.mock_local.assert_has_calls([
-            mock.call('CIRRUS_HOME/venv/bin/virtualenv CWD/venv'),
-            mock.call('CWD/venv/bin/pip install -i DEVPYPIURL -r requirements.txt'),
-            mock.call('. ./venv/bin/activate && python setup.py develop')
-        ])
-
     def test_execute_build_default_pypi_pip_options(self):
         """test execute_build with default pypi settings"""
         opts = mock.Mock()
@@ -196,7 +177,7 @@ class BuildCommandTests(TestCase):
         opts.extras = []
         opts.upgrade = False
         opts.nosetupdevelop = False
-        self.mock_conf.pypi_url.return_value = "PYPIURL"
+        self.mock_conf.pypi_url.return_value = "https://PYPIUSERNAME:TOKEN@PYPIURL/simple"
 
         execute_build(opts)
 
@@ -214,7 +195,7 @@ class BuildCommandTests(TestCase):
         opts.extras = []
         opts.nosetupdevelop = False
         opts.upgrade = True
-        self.mock_conf.pypi_url.return_value = "PYPIURL"
+        self.mock_conf.pypi_url.return_value = "https://PYPIUSERNAME:TOKEN@PYPIURL/simple"
 
         execute_build(opts)
 

--- a/tests/unit/cirrus/configuration_test.py
+++ b/tests/unit/cirrus/configuration_test.py
@@ -90,7 +90,7 @@ class ConfigurationTests(unittest.TestCase):
         self.assertEqual(config2.package_version(), '1.2.4')
 
     @mock.patch('cirrus.gitconfig.shell_command')
-    @mock.patch('cirrus.configuration.subprocess.Popen')
+    @mock.patch('subprocess.Popen')
     def test_reading_missing(self, mock_pop, mock_shell):
         """test config load using repo dir"""
         mock_result = mock.Mock()
@@ -155,7 +155,7 @@ class ConfigurationTests(unittest.TestCase):
         )
         config.credentials.pypi_credentials = mock.Mock()
         config.credentials.pypi_credentials.return_value = {
-            'username': 'doge@dogehous.bark',
+            'username': 'doge%40dogehous.bark',
             'token': 'wowsuchtoken'
         }
         self.assertEqual(


### PR DESCRIPTION
The latest pip (19.2) no longer allows un-quoted pypi urls.

- replaced PypircFile.get_pypi_url with Configuration.pypi_url
- replaced Configuration.pypi_url with Configuration.pypi_server
- Configuration.pypi_url now returns a full url

GitHub: https://github.com/cloudant/service_engineering/issues/319